### PR TITLE
Update SXSSFRow.cs

### DIFF
--- a/ooxml/XSSF/Streaming/SXSSFRow.cs
+++ b/ooxml/XSSF/Streaming/SXSSFRow.cs
@@ -48,7 +48,7 @@ namespace NPOI.XSSF.Streaming
         }
         public virtual bool HasCustomHeight()
         {
-            return Height != -1;
+            return _height != -1;
         }
 
         public List<ICell> Cells


### PR DESCRIPTION
```Height``` returns the combined value of the current row height and the ```Sheet.DefaultRowHeight```.
```_height``` returns the value of the row height.

Therefore I propose to use the row height here.

This code triggers although there is no custom row height set: https://github.com/nissl-lab/npoi/blob/4997d06aeb603359bab3cc9653cd03840a1dcfa4/ooxml/XSSF/Streaming/SheetDataWriter.cs#L229-L234